### PR TITLE
Fix checks for present/non-present registry values.

### DIFF
--- a/W10ANDW11-NETWORK-TCP-DESUBOPTIMIZATION.ps1
+++ b/W10ANDW11-NETWORK-TCP-DESUBOPTIMIZATION.ps1
@@ -1,21 +1,21 @@
-<# 
+<#
 .SYNOPSIS
-    This Script desuboptimize a lot W10 & W11 TCP Settings.   
- 
- .NOTES 
+    This Script desuboptimize a lot W10 & W11 TCP Settings.
+
+ .NOTES
     Version:        1.12
     Author:         MysticFoxDE (Alexander Fuchs)
     Creation Date:  22.02.2023
 
-.LINK 
+.LINK
     https://administrator.de/tutorial/wie-man-das-windows-10-und-11-tcp-handling-wieder-desuboptimieren-kann-5529700198.html#comment-5584260697
     https://community.spiceworks.com/topic/post/10299845
     https://www.golem.de/news/tcp-die-versteckte-netzwerkbremse-in-windows-10-und-11-2302-172043.html
 #>
 
 # PROMPT THE USER TO ELEVATE THE SCRIPT
-# Great thanks to "Karl Wester-Ebbinghaus/Karl-WE" for this very useful aid.   
-if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) 
+# Great thanks to "Karl Wester-Ebbinghaus/Karl-WE" for this very useful aid.
+if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
 {
   $arguments = "-NoExit -ExecutionPolicy Bypass -File `"$($myInvocation.MyCommand.Definition)`""
   Start-Process powershell -Verb runAs -ArgumentList $arguments
@@ -32,19 +32,19 @@ $FULLYCOMPLETED = $true
 $BAKLOGPATH = "C:\BACKUP"
 $BAKLOGFILENAME = "WINDOWS10AND11-NETWORK-DESUBOPTIMIZATION.log"
 $BAKLOGDATE = Get-Date
-if (!(Test-Path $BAKLOGPATH)) 
+if (!(Test-Path $BAKLOGPATH))
   {New-Item -Path $BAKLOGPATH -ItemType Directory}
 
 Write-Host ("Create a backup of the existing configuration under " + $BAKLOGPATH + "\" + $BAKLOGFILENAME) -ForegroundColor Cyan
 "************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME
 "*** Beginning of the configuration-backup from " + $BAKLOGDATE >> $BAKLOGPATH\$BAKLOGFILENAME
-"************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME  
-" " >> $BAKLOGPATH\$BAKLOGFILENAME  
-"Get-NetOffloadGlobalSetting: " >> $BAKLOGPATH\$BAKLOGFILENAME  
+"************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME
+" " >> $BAKLOGPATH\$BAKLOGFILENAME
+"Get-NetOffloadGlobalSetting: " >> $BAKLOGPATH\$BAKLOGFILENAME
 Get-NetOffloadGlobalSetting >> $BAKLOGPATH\$BAKLOGFILENAME
-"------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME  
-"netsh int tcp show global: " >> $BAKLOGPATH\$BAKLOGFILENAME 
-netsh int tcp show global >> $BAKLOGPATH\$BAKLOGFILENAME 
+"------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME
+"netsh int tcp show global: " >> $BAKLOGPATH\$BAKLOGFILENAME
+netsh int tcp show global >> $BAKLOGPATH\$BAKLOGFILENAME
 "------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME
 "netsh int tcp show supplemental:" >> $BAKLOGPATH\$BAKLOGFILENAME
 netsh int tcp show supplemental >> $BAKLOGPATH\$BAKLOGFILENAME
@@ -76,11 +76,11 @@ else
 "------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME
 "Status ACK-Frequency: (Registry)" >> $BAKLOGPATH\$BAKLOGFILENAME
 $NICs = Get-NetAdapter -Physical | Select-Object DeviceID, Name
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICGUID = $adapter | Select-Object DeviceID | Select DeviceID -ExpandProperty DeviceID | Out-String -Stream
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream 
+  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpAckFrequency" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpAckFrequency"
   if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
@@ -99,11 +99,11 @@ foreach ($adapter in $NICs)
 "------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME
 "Status TCP-Delay: (Registry)" >> $BAKLOGPATH\$BAKLOGFILENAME
 $NICs = Get-NetAdapter -Physical | Select-Object DeviceID, Name
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICGUID = $adapter | Select-Object DeviceID | Select DeviceID -ExpandProperty DeviceID | Out-String -Stream
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream 
+  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpNoDelay" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpNoDelay"
   if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
@@ -122,7 +122,7 @@ foreach ($adapter in $NICs)
 "------------------------------------------------------------------------------------------------------------" >> $BAKLOGPATH\$BAKLOGFILENAME
 "************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME
 "*** End of the configuration-backup from " + $BAKLOGDATE >> $BAKLOGPATH\$BAKLOGFILENAME
-"************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME 
+"************************************************************************************************************" >> $BAKLOGPATH\$BAKLOGFILENAME
 Write-Host ("Backup of the existing configuration is finished. :-)") -ForegroundColor Cyan
 
 # DISABLE PACKET COALESCING FILTER ON WINDOWS TCP-STACK
@@ -146,7 +146,7 @@ else
     {
     $DISABLEPCFOK = $false
     Write-Host ("  The PACKET COALESCING FILTER could not set to disabled. :-(") -ForegroundColor Red
-    if ($DEDAILEDDEBUG -eq "ON") 
+    if ($DEDAILEDDEBUG -eq "ON")
       {Write-Host $_ -ForegroundColor Red}
     }
   }
@@ -181,7 +181,7 @@ else
     {
     $DISABLERSSOK = $false
     Write-Host ("  The RECEIVE SIDE SCALING could not set to disabled. :-(") -ForegroundColor Red
-    if ($DEDAILEDDEBUG -eq "ON") 
+    if ($DEDAILEDDEBUG -eq "ON")
       {Write-Host $_ -ForegroundColor Red}
     }
   }
@@ -216,7 +216,7 @@ else
     {
     $DISABLERSCOK = $false
     Write-Host ("  The RECEIVE SEGMENT COALESCING could not set to disabled. :-(") -ForegroundColor Red
-    if ($DEDAILEDDEBUG -eq "ON") 
+    if ($DEDAILEDDEBUG -eq "ON")
       {Write-Host $_ -ForegroundColor Red}
     }
   }
@@ -245,21 +245,21 @@ try
     {
     $CHANGETCPCCOK = $false
     Write-Host "  The Update of the congestionprovider of the Datacenter TCP profile to DCTCP was NOT successfully. :-(" -ForegroundColor Red
-    Write-Host ("  " + $COMMANDOUTPUT) -ForegroundColor Red 
+    Write-Host ("  " + $COMMANDOUTPUT) -ForegroundColor Red
     }
   }
 catch
   {
   $CHANGETCPCCOK = $false
   Write-Host ("  The Update of the congestionprovider of the Datacenter TCP profile to DCTCP was NOT successfully. :-(") -ForegroundColor Red
-  if ($DEDAILEDDEBUG -eq "ON") 
+  if ($DEDAILEDDEBUG -eq "ON")
     {Write-Host $_ -ForegroundColor Red}
   }
 
 Write-Host "  Try to enable ECN" -ForegroundColor Gray
 try
   {
-  $COMMANDOUTPUT = Invoke-Expression -Command "netsh int tcp set global ECN=Enabled" -ErrorAction Stop | Out-String -Stream 
+  $COMMANDOUTPUT = Invoke-Expression -Command "netsh int tcp set global ECN=Enabled" -ErrorAction Stop | Out-String -Stream
   if ($COMMANDOUTPUT -eq "OK.")
     {
     Write-Host "  Enable ECN was successfully. :-)" -ForegroundColor Green
@@ -268,14 +268,14 @@ try
     {
     $CHANGETCPCCOK = $false
     Write-Host "  Try to enable ECN was NOT successfully. :-(" -ForegroundColor Red
-    Write-Host ("  " + $COMMANDOUTPUT) -ForegroundColor Red 
+    Write-Host ("  " + $COMMANDOUTPUT) -ForegroundColor Red
     }
   }
 catch
   {
   $CHANGETCPCCOK = $false
   Write-Host ("  Try to enable ECN was NOT successfully was NOT successfully. :-(") -ForegroundColor Red
-  if ($DEDAILEDDEBUG -eq "ON") 
+  if ($DEDAILEDDEBUG -eq "ON")
     {Write-Host $_ -ForegroundColor Red}
   }
 
@@ -290,7 +290,7 @@ if ($CHANGETCPCCOK -eq $true)
     Write-Host "TCP congestion controll can't finished successfully. :-(" -ForegroundColor Red
     }
 
-# CHANGE TCP PROFILE TO DATACENTERCUSTOM 
+# CHANGE TCP PROFILE TO DATACENTERCUSTOM
 Write-Host "Start TCP profile optimization" -ForegroundColor Cyan
 Write-Host "  Check if the key already exists in the registry." -ForegroundColor Gray
 $CHANGETCPPROFILEOK = $false
@@ -321,7 +321,7 @@ if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
     catch
       {
       Write-Host ("  The registry key could not be updated due to an error. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
       }
     }
@@ -338,7 +338,7 @@ else
   catch
     {
     Write-Host ("  The registry key could not be created due to an error. :-(") -ForegroundColor Red
-    if ($DEDAILEDDEBUG -eq "ON") 
+    if ($DEDAILEDDEBUG -eq "ON")
       {Write-Host $_ -ForegroundColor Red}
     }
   }
@@ -356,7 +356,7 @@ else
 $DISABLERSSOK = $true
 Write-Host "Start disabling RSS on all NIC's" -ForegroundColor Cyan
 Write-Host "  Check if NIC's with RSS support are avaible on this System." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RSS"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RSS"}
 $NICsWITHRSS = $NICs | Measure-Object -Line | Select-Object Lines | Select Lines -ExpandProperty Lines
 
 if ($NICsWITHRSS -eq 0)
@@ -366,13 +366,13 @@ if ($NICsWITHRSS -eq 0)
 else
   {
   Write-Host ("  " + $NICsWITHRSS + " NIC's found on this System that support RSS") -ForegroundColor Yellow
-  foreach ($adapter in $NICs) 
+  foreach ($adapter in $NICs)
     {
     $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-    $RSSVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
-  
+    $RSSVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
+
     Write-Host ("    Check RSS Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
     if ($RSSVALUE -eq "0")
       {
       Write-Host ("    RSS on NIC " + $NICNAME + " is already disabled, so, nothing to do. :-)") -ForegroundColor Green
@@ -389,7 +389,7 @@ else
         {
         $DISABLERSSOK = $false
         Write-Host ("  The RSS on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -409,7 +409,7 @@ if ($DISABLERSSOK -eq $true)
 $DISABLERSCIPV4OK = $true
 Write-Host "Start disabling RSC-IPv4 on all NIC's" -ForegroundColor Cyan
 Write-Host "  Check if NIC's with RSC-IPv4 support are avaible on this System." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RscIPv4"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RscIPv4"}
 $NICsWITHRSCIPV4 = $NICs | Measure-Object -Line | Select-Object Lines | Select Lines -ExpandProperty Lines
 
 if ($NICsWITHRSCIPV4 -eq 0)
@@ -419,13 +419,13 @@ if ($NICsWITHRSCIPV4 -eq 0)
 else
   {
   Write-Host ("  " + $NICsWITHRSCIPV4 + " NIC's found on this System that support RSC-IPv4") -ForegroundColor Yellow
-  foreach ($adapter in $NICs) 
+  foreach ($adapter in $NICs)
     {
     $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-    $RSCVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
-  
+    $RSCVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
+
     Write-Host ("    Check RSC-IPv4 Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
     if ($RSCVALUE -eq "0")
       {
       Write-Host ("    RSC-IPv4 on NIC " + $NICNAME + " is already disabled, so, nothing to do. :-)") -ForegroundColor Green
@@ -442,7 +442,7 @@ else
         {
         $DISABLERSCIPV4OK = $false
         Write-Host ("  The RSC-IPv4 on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -462,7 +462,7 @@ if ($DISABLERSCIPV4OK -eq $true)
 $DISABLERSCIPV6OK = $true
 Write-Host "Start disabling RSC-IPv6 on all NIC's" -ForegroundColor Cyan
 Write-Host "  Check if NIC's with RSC-IPv6 support are avaible on this System." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RscIPv6"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*RscIPv6"}
 $NICsWITHRSCIPV6 = $NICs | Measure-Object -Line | Select-Object Lines | Select Lines -ExpandProperty Lines
 
 if ($NICsWITHRSCIPV6 -eq 0)
@@ -472,13 +472,13 @@ if ($NICsWITHRSCIPV6 -eq 0)
 else
   {
   Write-Host ("  " + $NICsWITHRSCIPV6 + " NIC's found on this System that support RSC-IPv6") -ForegroundColor Yellow
-  foreach ($adapter in $NICs) 
+  foreach ($adapter in $NICs)
     {
     $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-    $RSCVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
-  
+    $RSCVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
+
     Write-Host ("    Check RSC-IPv6 Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
     if ($RSCVALUE -eq "0")
       {
       Write-Host ("    RSC-IPv6 on NIC " + $NICNAME + " is already disabled, so, nothing to do. :-)") -ForegroundColor Green
@@ -495,7 +495,7 @@ else
         {
         $DISABLERSCIPV6OK = $false
         Write-Host ("  The RSC-IPv6 on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -514,15 +514,15 @@ if ($DISABLERSCIPV6OK -eq $true)
 # DISABLE FLOW CONTROL ON ALL NIC's
 Write-Host "Start disabling FLOW CONTROL on all NIC's" -ForegroundColor Cyan
 Write-Host "  Identify the NICs that actually support FLOW CONTROL." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*FlowControl"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*FlowControl"}
 $DISABLEFCOK = $true
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
+  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
 
   Write-Host ("    Check FLOW CONTROL Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
   if ($EEEVALUE -eq "0")
     {
     Write-Host ("    The FLOW CONTROL is already disabled on NIC " + $NICNAME + ", so, nothing to do. :-)") -ForegroundColor Green
@@ -539,7 +539,7 @@ foreach ($adapter in $NICs)
       {
       $DISABLEFCOK = $false
       Write-Host ("  The FLOW CONTROL on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
         {Write-Host $_ -ForegroundColor Red}
       }
     }
@@ -557,15 +557,15 @@ if ($DISABLEFCOK -eq $true)
 # DISABLE INTERRUPT MODERATION ON ALL NIC's
 Write-Host "Start disabling INTERRUPT MODERATION on all NIC's" -ForegroundColor Cyan
 Write-Host "  Identify the NICs that actually support INTERRUPT MODERATION." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*InterruptModeration"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*InterruptModeration"}
 $DISABLEIMOK = $true
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
+  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
 
   Write-Host ("    Check INTERRUPT MODERATION Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
   if ($EEEVALUE -eq "0")
     {
     Write-Host ("    The INTERRUPT MODERATION is already disabled on NIC " + $NICNAME + ", so, nothing to do. :-)") -ForegroundColor Green
@@ -582,7 +582,7 @@ foreach ($adapter in $NICs)
       {
       $DISABLEIMOK = $false
       Write-Host ("  The INTERRUPT MODERATION on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
         {Write-Host $_ -ForegroundColor Red}
       }
     }
@@ -600,15 +600,15 @@ if ($DISABLEIMOK -eq $true)
 # DISABLE ENERGY-EFFICIENT-ETHERNET ON ALL NIC's
 Write-Host "Start disabling ENERGY-EFFICIENT-ETHERNET on all NIC's" -ForegroundColor Cyan
 Write-Host "  Identify the NICs that actually support ENERGY-EFFICIENT-ETHERNET." -ForegroundColor Gray
-$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*EEE"} 
+$NICs = Get-NetAdapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*EEE"}
 $DISABLEEEEEOK = $true
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream 
+  $EEEVALUE = $adapter | Select-Object RegistryValue | Select RegistryValue -ExpandProperty RegistryValue | Out-String -Stream
 
   Write-Host ("    Check EEE Status of NIC " + $NICNAME + " .") -ForegroundColor Gray
-  
+
   if ($EEEVALUE -eq "0")
     {
     Write-Host ("    The EEE is already disabled on NIC " + $NICNAME + ", so, nothing to do. :-)") -ForegroundColor Green
@@ -625,7 +625,7 @@ foreach ($adapter in $NICs)
       {
       $DISABLEEEEEOK = $false
       Write-Host ("  The EEE on NIC " + $NICNAME + ", could not set to disabled. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
         {Write-Host $_ -ForegroundColor Red}
       }
     }
@@ -642,14 +642,14 @@ if ($DISABLEEEEEOK -eq $true)
 
 # OPTIMIZE RECEIVE-BUFFERS ON ALL NIC's
 # Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*ReceiveBuffers"}
-$RECEIVEBUFFERSIZES = @(8192, 8184, 4096, 2048, 1024, 512, 256, 128)  
+$RECEIVEBUFFERSIZES = @(8192, 8184, 4096, 2048, 1024, 512, 256, 128)
 Write-Host "Start Receive-Buffer optimization" -ForegroundColor Cyan
-$NICs = Get-Netadapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*ReceiveBuffers"} 
-foreach ($adapter in $NICs) 
+$NICs = Get-Netadapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*ReceiveBuffers"}
+foreach ($adapter in $NICs)
   {
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
   $CHANGERBOK = "NO"
-  foreach ($RECEIVEBUFFESIZE in $RECEIVEBUFFERSIZES) 
+  foreach ($RECEIVEBUFFESIZE in $RECEIVEBUFFERSIZES)
     {
     if ($CHANGERBOK -eq "NO")
       {
@@ -664,7 +664,7 @@ foreach ($adapter in $NICs)
         {
         Write-Host ("  Oops, the NIC " + $NICNAME + " does not accept a receive buffer size of " + $RECEIVEBUFFESIZE + "KB ... :-( ... never mind ... try with a smaller buffer next.") -ForegroundColor Yellow
         $CHANGERBOK = "NO"
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -674,14 +674,14 @@ Write-Host "Receive-Buffer optimization is complitly finished." -ForegroundColor
 
 # OPTIMIZE TRANSMIT-BUFFERS ON ALL NIC's
 # Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*TransmitBuffers"}
-$TRANSMITBUFFERSIZES = @(8192, 8184, 4096, 2048, 1024, 512, 256, 128)  
+$TRANSMITBUFFERSIZES = @(8192, 8184, 4096, 2048, 1024, 512, 256, 128)
 Write-Host "Start Transmit-Buffer optimization" -ForegroundColor Cyan
-$NICs = Get-Netadapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*TransmitBuffers"} 
-foreach ($adapter in $NICs) 
+$NICs = Get-Netadapter -Physical | Get-NetAdapterAdvancedProperty | Where-Object -FilterScript {$_.RegistryKeyword -Like "*TransmitBuffers"}
+foreach ($adapter in $NICs)
   {
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
   $CHANGETBOK = "NO"
-  foreach ($TRANSMITBUFFESIZE in $TRANSMITBUFFERSIZES) 
+  foreach ($TRANSMITBUFFESIZE in $TRANSMITBUFFERSIZES)
     {
     if ($CHANGETBOK -eq "NO")
       {
@@ -696,7 +696,7 @@ foreach ($adapter in $NICs)
         {
         Write-Host ("  Oops, the NIC " + $NICNAME + " does not accept a transmit buffer size of " + $TRANSMITBUFFESIZE + "KB ... :-( ... never mind ... try with a smaller buffer next.") -ForegroundColor Yellow
         $CHANGETBOK = "NO"
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -704,15 +704,15 @@ foreach ($adapter in $NICs)
   }
 Write-Host "Transmit-Buffer optimization is complitly finished." -ForegroundColor Cyan
 
-# OPTIMIZE TCPACKFREQUENCY 
+# OPTIMIZE TCPACKFREQUENCY
 Write-Host "Start ACK-Frequency optimization" -ForegroundColor Cyan
 $NICs = Get-NetAdapter -Physical | Select-Object DeviceID, Name
 $CHANGETCPACKFREQUENCYOK = $true
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICGUID = $adapter | Select-Object DeviceID | Select DeviceID -ExpandProperty DeviceID | Out-String -Stream
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream 
+  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
 
   Write-Host ("  Check if the key already exists in the registry for NIC " + $NICNAME + " .") -ForegroundColor Gray
   $TARGETVALUE = 1
@@ -741,7 +741,7 @@ foreach ($adapter in $NICs)
         {
         $CHANGETCPACKFREQUENCYOK = $false
         Write-Host ("  The registry key for NIC " + $NICNAME + " could not be updated due to an error. :-(") -ForegroundColor Red
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -758,7 +758,7 @@ foreach ($adapter in $NICs)
       {
       $CHANGETCPACKFREQUENCYOK = $false
       Write-Host ("  The registry key could not be created due to an error. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
         {Write-Host $_ -ForegroundColor Red}
       }
     }
@@ -773,15 +773,15 @@ if ($CHANGETCPACKFREQUENCYOK -eq $true)
     Write-Host "ACK-Frequency optimization can't finished successfully. :-(" -ForegroundColor Red
     }
 
-# OPTIMIZE TCPDELAY 
+# OPTIMIZE TCPDELAY
 Write-Host "Start TCP-Delay optimization" -ForegroundColor Cyan
 $NICs = Get-NetAdapter -Physical | Select-Object DeviceID, Name
 $CHANGETCPDELAYOK = $true
-foreach ($adapter in $NICs) 
+foreach ($adapter in $NICs)
   {
   $NICGUID = $adapter | Select-Object DeviceID | Select DeviceID -ExpandProperty DeviceID | Out-String -Stream
   $NICNAME = $adapter | Select-Object Name | Select Name -ExpandProperty Name | Out-String -Stream
-  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream 
+  $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
 
   Write-Host ("  Check if the key already exists in the registry for NIC " + $NICNAME + " .") -ForegroundColor Gray
   $TARGETVALUE = 1
@@ -810,7 +810,7 @@ foreach ($adapter in $NICs)
         {
         $CHANGETCPDELAYOK = $false
         Write-Host ("  The registry key for NIC " + $NICNAME + " could not be updated due to an error. :-(") -ForegroundColor Red
-        if ($DEDAILEDDEBUG -eq "ON") 
+        if ($DEDAILEDDEBUG -eq "ON")
           {Write-Host $_ -ForegroundColor Red}
         }
       }
@@ -827,7 +827,7 @@ foreach ($adapter in $NICs)
       {
       $CHANGETCPDELAYOK = $false
       Write-Host ("  The registry key could not be created due to an error. :-(") -ForegroundColor Red
-      if ($DEDAILEDDEBUG -eq "ON") 
+      if ($DEDAILEDDEBUG -eq "ON")
         {Write-Host $_ -ForegroundColor Red}
       }
     }

--- a/W10ANDW11-NETWORK-TCP-DESUBOPTIMIZATION.ps1
+++ b/W10ANDW11-NETWORK-TCP-DESUBOPTIMIZATION.ps1
@@ -61,11 +61,7 @@ Get-NetAdapterRss >> $BAKLOGPATH\$BAKLOGFILENAME
 "Status TCP-Profile: (Registry)" >> $BAKLOGPATH\$BAKLOGFILENAME
 $TARGETVALUE = @([byte[]](0x03,0x00,0x00,0x00,0xff,0xff,0xff,0xff))
 $CHECKVALUE =  @([byte[]](Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Nsi\{eb004a03-9b1a-11d4-9123-0050047759bc}\27\" -Name "06000000" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "06000000"))
-if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-  {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-else
-  {$AREEQUAL = $false}
-if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
   {
     ("The 06000000 Key is present in the registry with value " + $CHECKVALUE + ".") >> $BAKLOGPATH\$BAKLOGFILENAME
   }
@@ -83,11 +79,7 @@ foreach ($adapter in $NICs)
   $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpAckFrequency" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpAckFrequency"
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-    {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-  else
-    {$AREEQUAL = $false}
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+  if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
     {
     ("The TcpAckFrequency Key for NIC " + $NICNAME + " is present in the registry with value " + $CHECKVALUE + ".") >> $BAKLOGPATH\$BAKLOGFILENAME
     }
@@ -106,11 +98,7 @@ foreach ($adapter in $NICs)
   $REGKEYPATH = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$NICGUID\" | Out-String -Stream
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpNoDelay" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpNoDelay"
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-    {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-  else
-    {$AREEQUAL = $false}
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+  if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
     {
     ("The TcpNoDelay Key for NIC " + $NICNAME + " is present in the registry with value " + $CHECKVALUE + ".") >> $BAKLOGPATH\$BAKLOGFILENAME
     }
@@ -296,14 +284,11 @@ Write-Host "  Check if the key already exists in the registry." -ForegroundColor
 $CHANGETCPPROFILEOK = $false
 $TARGETVALUE = @([byte[]](0x03,0x00,0x00,0x00,0xff,0xff,0xff,0xff))
 $CHECKVALUE =  @([byte[]](Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Nsi\{eb004a03-9b1a-11d4-9123-0050047759bc}\27\" -Name "06000000" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "06000000"))
-if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-  {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-else
-  {$AREEQUAL = $false}
-if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
   {
   Write-Host "  The value is present in the registry." -ForegroundColor Yellow
   Write-Host "  Checking the already existing parameter." -ForegroundColor Gray
+  $AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0
   if ($AREEQUAL -eq $true)
     {
     Write-Host "  The settings are already set correctly, no further measures are required." -ForegroundColor Green
@@ -717,14 +702,11 @@ foreach ($adapter in $NICs)
   Write-Host ("  Check if the key already exists in the registry for NIC " + $NICNAME + " .") -ForegroundColor Gray
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpAckFrequency" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpAckFrequency"
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-    {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-  else
-    {$AREEQUAL = $false}
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+  if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
     {
     Write-Host ("    The key for NIC " + $NICNAME + " is present in the registry.") -ForegroundColor Yellow
     Write-Host ("    Checking the already existing key of NIC " + $NICNAME + ".") -ForegroundColor Gray
+    $AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0
     if ($AREEQUAL -eq $true)
       {
       Write-Host ("  The settings of NIC " + $NICNAME + " are already set correctly, no further measures are required.") -ForegroundColor Green
@@ -786,14 +768,11 @@ foreach ($adapter in $NICs)
   Write-Host ("  Check if the key already exists in the registry for NIC " + $NICNAME + " .") -ForegroundColor Gray
   $TARGETVALUE = 1
   $CHECKVALUE = Get-ItemProperty -Path "$REGKEYPATH" -Name "TcpNoDelay" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty "TcpNoDelay"
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
-    {$AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0}
-  else
-    {$AREEQUAL = $false}
-  if (($CHECKVALUE -ne $null) -or ($CHECKVALUE.Length -ne 0))
+  if (($CHECKVALUE -ne $null) -and ($CHECKVALUE.Length -gt 0))
     {
     Write-Host ("    The key for NIC " + $NICNAME + " is present in the registry.") -ForegroundColor Yellow
     Write-Host ("    Checking the already existing key of NIC " + $NICNAME + ".") -ForegroundColor Gray
+    $AREEQUAL = @(Compare-Object $TARGETVALUE $CHECKVALUE -SyncWindow 0).Length -eq 0
     if ($AREEQUAL -eq $true)
       {
       Write-Host ("  The settings of NIC " + $NICNAME + " are already set correctly, no further measures are required.") -ForegroundColor Green


### PR DESCRIPTION
This commit fixes an issue which prevents non-existing properties such as `06000000` from being created.